### PR TITLE
Add patch to allow using OpenSSL 3's ABI compatibility

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/0002-ssh_compatible_openssl-for-openssl3.diff
+++ b/recipe/0002-ssh_compatible_openssl-for-openssl3.diff
@@ -1,0 +1,41 @@
+--- a/openbsd-compat/openssl-compat.c	
++++ a/openbsd-compat/openssl-compat.c	
+@@ -48,21 +48,28 @@ ssh_compatible_openssl(long headerver, long libver)
+ 	if (headerver == libver)
+ 		return 1;
+ 
+-	/* for versions < 1.0.0, major,minor,fix,status must match */
+-	if (headerver < 0x1000000f) {
+-		mask = 0xfffff00fL; /* major,minor,fix,status */
+-		return (headerver & mask) == (libver & mask);
+-	}
+-
+ 	/*
+-	 * For versions >= 1.0.0, major,minor,status must match and library
++	 * For versions < 3.0.0, major,minor,status must match and library
+ 	 * fix version must be equal to or newer than the header.
+ 	 */
+-	mask = 0xfff0000fL; /* major,minor,status */
+-	hfix = (headerver & 0x000ff000) >> 12;
+-	lfix = (libver & 0x000ff000) >> 12;
++	if (headerver < 0x3000000f) {
++		mask = 0xfff0000fL; /* major,minor,status */
++		hfix = (headerver & 0x000ff000) >> 12;
++		lfix = (libver & 0x000ff000) >> 12;
++		if ( (headerver & mask) == (libver & mask) && lfix >= hfix)
++			return 1;
++	}
++
++	/*
++	 * For versions >= 3.0.0, major must match and minor,status must be
++	 * equal to or greater than the header.
++	 */
++	mask = 0xf000000fL; /* major, status */
++	hfix = (headerver & 0x0ffffff0L) >> 12;
++	lfix = (libver & 0x0ffffff0L) >> 12;
+ 	if ( (headerver & mask) == (libver & mask) && lfix >= hfix)
+ 		return 1;
++
+ 	return 0;
+ }
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8
   patches:
     - 0001-Set-strip-program-when-running-install.patch  # [linux]
+    - 0002-ssh_compatible_openssl-for-openssl3.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Since OpenSSL 3.1 was released OpenSSH has been failing with:

```
OpenSSL version mismatch. Built against 30000050, you have 30100000
```

This is a bug in their compatibility checking code so I'll pick up the patch for it rather than pinning tighter: https://bugzilla.mindrot.org/show_bug.cgi?id=3548